### PR TITLE
Adding package.json file to allow NPM installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "medium-editor-autolist",
+  "version": "1.0.0",
+  "description": "An extension for medium editor which auto creates list.",
+  "main": "dist/autolist.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gruberro/medium-editor-autolist.git"
+  },
+  "keywords": [
+    "medium-editor",
+    "extension",
+    "autolist"
+  ],
+  "author": "Varun Raj <mailme@varunraj.in>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gruberro/medium-editor-autolist/issues"
+  },
+  "homepage": "https://github.com/gruberro/medium-editor-autolist#readme"
+}


### PR DESCRIPTION
It would be great to install your `medium-editor`-extension by NPM too. Most of the existing extensions out there are supporting NPM. I know that there are some workarounds with NPM (e.g. `napa`), but there are a lot of drawbacks when doing this hacky stuff.
