### PR TITLE
Trigger unordered list for both * and -

### DIFF
--- a/dist/autolist.js
+++ b/dist/autolist.js
@@ -22,7 +22,7 @@
         this.base.execAction('delete');
         this.base.execAction('insertorderedlist');
       }
-      else if (/^\s*\*\s/.test(list_start) && this.base.getExtensionByName('unorderedlist')){
+      else if (/^\s*[*-]\s/.test(list_start) && this.base.getExtensionByName('unorderedlist')){
         this.base.execAction('delete');
         this.base.execAction('delete');
         this.base.execAction('insertunorderedlist');


### PR DESCRIPTION
Often, unordered lists get created with a hyphen ("-") and not just with an asterisk ("*"). This would allow these to be transformed into unordered lists as well.

Let me know if you encounter any issues with the approach. 